### PR TITLE
[jiho] 전역에서 사용될 config 클래스를 모아놓은 패키지 이름을 global_config으로 변경

### DIFF
--- a/src/main/java/com/example/outgoit/global_config/ResourceHandler.java
+++ b/src/main/java/com/example/outgoit/global_config/ResourceHandler.java
@@ -1,4 +1,4 @@
-package com.example.outgoit.config;
+package com.example.outgoit.global_config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;


### PR DESCRIPTION
나중에 알아보기 쉬우라고 패키지 이름을 변경했음